### PR TITLE
Comms

### DIFF
--- a/sandbox/urls.py
+++ b/sandbox/urls.py
@@ -1,6 +1,4 @@
 """config URL Configuration 4.1"""
-# import os
-
 from django.conf import settings
 from django.conf.urls.i18n import i18n_patterns
 from django.conf.urls.static import static
@@ -11,7 +9,9 @@ from django.urls import include, path
 from src.core.utils.views_help import clear
 from src.core.views import home
 
-# from django.views.generic import TemplateView
+# handler404 = "src.core.utils.views_help.handler404"
+# handler500 = "src.core.utils.views_help.handler500"
+
 
 urlpatterns = [
     # path(eve('SECRET_ADMIN_URL') + '/admin/', admin.site.urls),

--- a/src/comments/models.py
+++ b/src/comments/models.py
@@ -39,7 +39,7 @@ class Comment(TimeStamp, MP_Node):
         ordering = ("path",)
 
     def __str__(self):
-        return f"commet to {self.body}"
+        return f"Body: {self.body}"
 
     # TODO: add time delta : created_at  == updated_at for edit
     @property

--- a/src/comments/tests/test_htmx_forms.py
+++ b/src/comments/tests/test_htmx_forms.py
@@ -1,6 +1,3 @@
-from pprint import pprint
-
-from django.template.loader import render_to_string
 from django.test import override_settings
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _

--- a/src/comments/urls.py
+++ b/src/comments/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 
 from .views import (
     display_all_comments,
+    display_selected_comments,
     get_reply_form,
     handle_delete_comment,
     handle_edit_comment,
@@ -12,6 +13,11 @@ app_name = "comments"
 
 urlpatterns = [
     path("all-comms/<post_uuid>/", display_all_comments, name="all_comms"),
+    path(
+        "selected-thread/<post_uuid>/<thread_uuid>/",
+        display_selected_comments,
+        name="select_comms",
+    ),
     # create
     path("add-comm/<post_uuid>/<comm_id>/", get_reply_form, name="add_comm"),
     path("process-reply/<post_uuid>/", process_reply, name="process_comm"),

--- a/src/comments/views.py
+++ b/src/comments/views.py
@@ -35,7 +35,7 @@ def get_reply_form(request, post_uuid, comm_id):
 def process_reply(request, post_uuid):
     """
     if parent comm is deleted->no notifications;
-    also no notif on users own comment
+    also no notif users own comment
     """
     form = CommentForm(request.POST)
     if form.is_valid():
@@ -51,17 +51,7 @@ def process_reply(request, post_uuid):
         comm.body = comm_body
         if replied_to == request.user:
             comm.own_reply = True
-        # comm.save()
         parent_comm.add_child(instance=comm)
-        # if not parent_comm.deleted and (replied_to != request.user):
-        #     short_body = comm_body[:100]
-        #     msg = f"User {comm.user} replied to your comment: {short_body}"
-        #     new_notif = Notification.objects.create(
-        #         recipient=replied_to, text=msg, post=post, parent_comment=parent_comm
-        #     )
-        #     print("new notif created", new_notif)
-        # else:
-        #     print("user replied to himself")
         return HttpResponse(status=204, headers={"HX-Trigger": "updateCommList"})
 
 

--- a/src/comments/views.py
+++ b/src/comments/views.py
@@ -6,11 +6,14 @@ from django.views.decorators.http import require_http_methods
 
 from src.comments.forms import CommentForm
 from src.comments.models import Comment
-from src.notifications.models import Notification
 from src.posts.models.post_model import Post
 
 
 def display_all_comments(request, post_uuid):
+    """
+    htmx based; triggered if post detail page
+    loaded or comments updated
+    """
     post = Post.objects.get(uuid=post_uuid)
     post_comms = Comment.objects.filter(post=post)
     return render(
@@ -20,9 +23,24 @@ def display_all_comments(request, post_uuid):
     )
 
 
+def display_selected_comments(request, post_uuid, thread_uuid):
+    """
+    htmx based;
+    triggered from dropdown-menu link:
+    comments refer to replied comment and it's children
+    """
+    post = Post.objects.get(uuid=post_uuid)
+    post_comms = Comment.objects.filter(post=post, uuid=thread_uuid)
+    return render(
+        request,
+        "components/comms/wraps.html",
+        {"comments": post_comms, "post": post, "user": request.user},
+    )
+
+
 @login_required
 def get_reply_form(request, post_uuid, comm_id):
-    """get req to get form for reply"""
+    """htmx + modal; get req to get form for reply"""
     form = CommentForm(initial={"comm_parent_id": comm_id})
     ctx = {}
     ctx["form"] = form
@@ -34,8 +52,10 @@ def get_reply_form(request, post_uuid, comm_id):
 @login_required
 def process_reply(request, post_uuid):
     """
-    if parent comm is deleted->no notifications;
-    also no notif users own comment
+    htmx-modal;
+    no notifications in cases:
+    - parent(replied) comm is deleted;
+    - users comment their own comment
     """
     form = CommentForm(request.POST)
     if form.is_valid():
@@ -57,7 +77,11 @@ def process_reply(request, post_uuid):
 
 @login_required
 def handle_edit_comment(request, post_uuid, comm_id):
-    """htmx based + modal UI in bootstrap5"""
+    """
+    htmx based + modal UI in bootstrap5;
+    provide pre-filled comment form and proccess it.
+    incl method PUT (htmx)
+    """
 
     ctx = {"post_uuid": post_uuid, "comm_id": comm_id}
     post = get_object_or_404(Post, uuid=post_uuid)
@@ -66,26 +90,20 @@ def handle_edit_comment(request, post_uuid, comm_id):
     if request.method == "GET":
         if parent:
             form = CommentForm(instance=obj, initial={"comm_parent_id": comm_id})
-
         else:
-            print("should be a root comment")
             form = CommentForm(instance=obj)
         ctx["form"] = form
         return render(request, "components/comms/comm_edit_form.html", ctx)
 
     if request.method == "PUT":
         data_dict = QueryDict(request.body).dict()
-
         form = CommentForm(data_dict, instance=obj)
         if form.is_valid():
-            print("cleaned data reply is ", form.cleaned_data)
             obj.updated_at = timezone.now()
             obj.save()
             return HttpResponse(status=204, headers={"HX-Trigger": "updateCommList"})
         else:
-            print("form NOT valid")
-            print("errs: ", form.errors)
-            ctx["fomr"] = form
+            ctx["form"] = form
     return render(request, "components/comms/comm_edit_form.html", ctx)
 
 

--- a/src/contacts/forms.py
+++ b/src/contacts/forms.py
@@ -31,6 +31,16 @@ class ContactForm(forms.Form):
     #     #     private_key=settings.RECAPTCHA_PRIVATE_KEY,
     #     # )
 
+    def __init__(self, **kwargs):
+        """if user is auth form should be pre-filled with exist user data"""
+        self.request = kwargs.pop("request")
+        super().__init__(**kwargs)
+        if self.request:
+            name = self.fields["name"]
+            name.initial = self.request.user.username
+            email = self.fields["email"]
+            email.initial = self.request.user.email
+
     def clean_message(self):
         message = self.cleaned_data.get("message", "no input")
         words = message.split()

--- a/src/contacts/tests/test_web.py
+++ b/src/contacts/tests/test_web.py
@@ -39,6 +39,7 @@ class ContactFormTest(WebTest):
     def setUp(self):
         super().setUp()
         self.url = reverse("contacts:feedback")
+        self.user = UserFactory(username="Snork", email="jaga@mail.com")
 
     def test_contact_form_valid(self):
         response = self.app.get(self.url)
@@ -56,6 +57,18 @@ class ContactFormTest(WebTest):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(len(messages), 1)
         self.assertEqual(str(messages[0]), _("Your message is sent"))
+
+    def test_contact_form_auth_user(self):
+        """auth loggen in user's form is pre-filled with name and mail"""
+        self.app.set_user(self.user)
+        response = self.app.get(self.url)
+        self.assertEqual(response.status_code, 200)
+
+        form = response.forms["feedback"]
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(form["name"].value, "Snork")
+        self.assertEqual(form["email"].value, "jaga@mail.com")
 
     def test_contact_form_honeypot(self):
         response = self.app.get(self.url)
@@ -77,8 +90,8 @@ class ContactFormTest(WebTest):
             resp.context["form"].errors, {"honeypot": [_("It should not be here")]}
         )
 
-    def test_short_msg(self):
-        """min 2 words in message"""
+    def test_failure_short_msg(self):
+        """failure: error min 2 words in message"""
 
         response = self.app.get(self.url)
         form = response.forms["feedback"]

--- a/src/contacts/tests/test_web.py
+++ b/src/contacts/tests/test_web.py
@@ -16,20 +16,20 @@ class SubscribeLinkTest(WebTest):
     def test_auth_user_has_subscr_link_in_menu(self):
         """Auth user has link to subscribe for a newsletter"""
         self.app.set_user(self.user)
-        self.response = self.app.get(self.url)
-        self.assertEqual(self.response.status_code, 200)
+        response = self.app.get(self.url)
+        self.assertEqual(response.status_code, 200)
 
-        subs_link = self.response.html.find("a", id="subLink")
+        subs_link = response.html.find("a", id="subLink")
 
         self.assertIsNotNone(subs_link)
 
     def test_unauth_user_no_link_in_menu(self):
         """Unauth used - no link in menu to subscribe for a newsletter"""
 
-        self.response = self.app.get(self.url)
-        self.assertEqual(self.response.status_code, 200)
+        response = self.app.get(self.url)
+        self.assertEqual(response.status_code, 200)
 
-        subs_link = self.response.html.find("a", id="subLink")
+        subs_link = response.html.find("a", id="subLink")
 
         self.assertIsNone(subs_link)
 

--- a/src/contacts/views.py
+++ b/src/contacts/views.py
@@ -1,6 +1,6 @@
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin as LRM
-from django.core.mail import BadHeaderError, send_mail
+from django.core.mail import send_mail
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.template.loader import get_template
@@ -90,6 +90,14 @@ class ContactView(FormView):
     template_name = "contacts/feedback/feedback.html"
     form_class = ContactForm
     success_url = reverse_lazy("home")
+
+    def get_form_kwargs(self) -> dict:
+        kwargs = super().get_form_kwargs()
+        if self.request.user.is_authenticated:
+            kwargs.update({"request": self.request})
+        else:
+            kwargs.update({"request": None})
+        return kwargs
 
     def form_valid(self, form):
         name = form.cleaned_data.get("name")

--- a/src/contacts/views.py
+++ b/src/contacts/views.py
@@ -60,6 +60,9 @@ class UnSubscribe(View):
 
     def post(self, request, **kwargs):
         # htmx_based
+        """
+        if OK -> redirect ot Home page with success msg
+        """
         htmx_req = request.headers.get("hx-request")
         try:
             uuid = kwargs.get("uuid")
@@ -77,9 +80,7 @@ class UnSubscribe(View):
                 raise HtmxFailureError(_("Something went wrong.Can't unsubscribe."))
         except HtmxFailureError:
             raise
-            # raise Http404(
-            #     _("Something wrong; Failed to unsubscribe")
-            # )
+
         return HttpResponseRedirect("/")
 
 

--- a/src/notifications/models.py
+++ b/src/notifications/models.py
@@ -28,7 +28,7 @@ class NotificationManager(models.Manager):
 
     def make_all_read(self, recipient):
         qs = self.get_queryset().filter(recipient=recipient, read=False)
-        qs.update(read=True)
+        return qs.update(read=True)
 
 
 class Notification(models.Model):
@@ -52,4 +52,4 @@ class Notification(models.Model):
         ordering = ["-created"]
 
     def __str__(self):
-        return f"Notification for {self.recipient} | id={self.id}"
+        return f"Notification for {self.recipient}"

--- a/src/notifications/tests/factories.py
+++ b/src/notifications/tests/factories.py
@@ -1,0 +1,16 @@
+import factory
+
+from src.accounts.models import User
+from src.comments.models import Comment
+from src.notifications.models import Notification
+from src.posts.models.post_model import Post
+
+
+class NotificationFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Notification
+
+    recipient = factory.SubFactory(User)
+    text = factory.Faker("sentence")
+    post = factory.SubFactory(Post)
+    comment = factory.SubFactory(Comment)

--- a/src/notifications/tests/test_model.py
+++ b/src/notifications/tests/test_model.py
@@ -1,0 +1,50 @@
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
+
+from src.accounts.tests.factories import UserFactory
+from src.comments.models import Comment
+from src.notifications.models import Notification
+from src.posts.tests.factories import PostFactory
+
+
+@override_settings(LANGUAGE_CODE="en", LANGUAGES=(("en", "English"),))
+class NotificationsMenuTestCase(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.user = UserFactory(username="tata")
+        self.author_comment = UserFactory(username="sally")
+        self.post = PostFactory.create(
+            status=2,
+        )
+        self.comment = Comment.add_root(
+            post=self.post, user=self.author_comment, body="it's me, root comment"
+        )
+
+    def test_count_unread_comms(self):
+        """test manager Notification"""
+        self.client.force_login(self.user)
+        # create 5 comments on root comment
+        [
+            self.comment.add_child(
+                post=self.post, body="bar", user=self.user, reply_to=self.author_comment
+            )
+            for _ in range(5)  # noqa
+        ]
+
+        url = reverse("home")
+
+        headers = {"HTTP_HX-Request": "true"}
+
+        resp = self.client.get(url, **headers)
+
+        all_notifs_count = Notification.objects.all_notifics(
+            recipient=self.author_comment
+        ).count()
+        notif_unread_count = Notification.objects.count_unread_notifics(
+            recipient=self.author_comment
+        )
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(notif_unread_count, 5)
+        self.assertEqual(all_notifs_count, 5)

--- a/src/notifications/tests/test_views.py
+++ b/src/notifications/tests/test_views.py
@@ -1,0 +1,109 @@
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
+
+from src.accounts.tests.factories import UserFactory
+from src.comments.models import Comment
+from src.notifications.models import Notification
+from src.posts.tests.factories import PostFactory
+
+
+@override_settings(LANGUAGE_CODE="en", LANGUAGES=(("en", "English"),))
+class NotificationsFabricTestCase(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.user = UserFactory(username="tata")
+        self.author_comment = UserFactory(username="sally")
+        self.post = PostFactory.create(
+            title_en="Bell's palsy",
+            content_en="herpes virus, treatment,prednisone",
+            status=2,
+        )
+        self.comment = Comment.add_root(
+            post=self.post, user=self.author_comment, body="it's me, root comment"
+        )
+
+    def test_notific_on_reply_comment(self):
+        """test adding child comment(reply to a root comment)"""
+        self.client.force_login(self.user)
+        url = reverse(
+            "comments:process_comm",
+            kwargs={"post_uuid": self.post.uuid},
+        )
+        data = {
+            "body": "Tata replies Sally",
+            "comm_parent_id": self.comment.id,
+            "post": self.post,
+        }
+        headers = {"HTTP_HX-Request": "true"}
+
+        resp = self.client.post(url, data=data, **headers)
+
+        notif_count = Notification.objects.count()
+        notif_to_author = Notification.objects.last()
+
+        self.assertEqual(resp.status_code, 204)
+        self.assertFalse(notif_to_author.read)
+        self.assertEqual(notif_to_author.post, self.post)
+        self.assertEqual(notif_to_author.parent_comment, self.comment)
+        self.assertEqual(notif_to_author.recipient, self.author_comment)
+        self.assertEqual(notif_count, 1)
+
+    def test_no_notif_own_reply_to_yourself(self):
+        """if user reply's own comment -> no notifications"""
+        self.client.force_login(self.author_comment)
+        url = reverse(
+            "comments:process_comm",
+            kwargs={"post_uuid": self.post.uuid},
+        )
+        data = {
+            "body": "Sally reply's to herself",
+            "comm_parent_id": self.comment.id,
+            "post": self.post,
+        }
+        headers = {"HTTP_HX-Request": "true"}
+
+        resp = self.client.post(url, data=data, **headers)
+
+        notif_count = Notification.objects.count()
+
+        self.assertEqual(resp.status_code, 204)
+        self.assertEqual(notif_count, 0)
+
+
+@override_settings(LANGUAGE_CODE="en", LANGUAGES=(("en", "English"),))
+class MarkNotificationsAsReadTestCase(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.user = UserFactory(username="tata")
+        self.author_comment = UserFactory(username="sally")
+        self.post = PostFactory.create(
+            title_en="Bell's palsy",
+            content_en="herpes virus, treatment,prednisone",
+            status=2,
+        )
+        self.root_comment = Comment.add_root(
+            post=self.post, user=self.author_comment, body="it's me, root comment"
+        )
+        self.notif_1 = Notification.objects.create(
+            recipient=self.user, parent_comment=self.root_comment, post=self.post
+        )
+        self.notif_2 = Notification.objects.create(
+            recipient=self.user, parent_comment=self.root_comment, post=self.post
+        )
+
+    def test_notific_on_reply_comment(self):
+        """mark first 5 top notifications as read"""
+        self.client.force_login(self.user)
+        url = reverse(
+            "notifications:mark_top_read",
+        )
+        headers = {"HTTP_HX-Request": "true"}
+
+        resp = self.client.post(url, **headers)
+
+        notifs = Notification.objects.all()
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(notifs[0].read)
+        self.assertTrue(notifs[1].read)

--- a/src/notifications/tests/test_views.py
+++ b/src/notifications/tests/test_views.py
@@ -4,6 +4,7 @@ from django.utils.translation import gettext_lazy as _
 
 from src.accounts.tests.factories import UserFactory
 from src.comments.models import Comment
+from src.contacts.exceptions import HtmxFailureError
 from src.notifications.models import Notification
 from src.posts.tests.factories import PostFactory
 
@@ -49,26 +50,27 @@ class NotificationsFabricTestCase(TestCase):
         self.assertEqual(notif_to_author.recipient, self.author_comment)
         self.assertEqual(notif_count, 1)
 
-    def test_no_notif_own_reply_to_yourself(self):
-        """if user reply's own comment -> no notifications"""
-        self.client.force_login(self.author_comment)
-        url = reverse(
-            "comments:process_comm",
-            kwargs={"post_uuid": self.post.uuid},
-        )
-        data = {
-            "body": "Sally reply's to herself",
-            "comm_parent_id": self.comment.id,
-            "post": self.post,
-        }
-        headers = {"HTTP_HX-Request": "true"}
 
-        resp = self.client.post(url, data=data, **headers)
+def test_no_notif_own_reply_to_yourself(self):
+    """if user reply's own comment -> no notifications"""
+    self.client.force_login(self.author_comment)
+    url = reverse(
+        "comments:process_comm",
+        kwargs={"post_uuid": self.post.uuid},
+    )
+    data = {
+        "body": "Sally reply's to herself",
+        "comm_parent_id": self.comment.id,
+        "post": self.post,
+    }
+    headers = {"HTTP_HX-Request": "true"}
 
-        notif_count = Notification.objects.count()
+    resp = self.client.post(url, data=data, **headers)
 
-        self.assertEqual(resp.status_code, 204)
-        self.assertEqual(notif_count, 0)
+    notif_count = Notification.objects.count()
+
+    self.assertEqual(resp.status_code, 204)
+    self.assertEqual(notif_count, 0)
 
 
 @override_settings(LANGUAGE_CODE="en", LANGUAGES=(("en", "English"),))
@@ -92,13 +94,13 @@ class MarkNotificationsAsReadTestCase(TestCase):
             recipient=self.user, parent_comment=self.root_comment, post=self.post
         )
 
-    def test_notific_on_reply_comment(self):
-        """mark first 5 top notifications as read"""
+    def test_mark_notific_as_read(self):
+        """mark all notifications as read"""
         self.client.force_login(self.user)
         url = reverse(
             "notifications:mark_top_read",
         )
-        headers = {"HTTP_HX-Request": "true"}
+        headers = {"HTTP_HX-Request": "true", "HTTP_REFERER": "foo"}
 
         resp = self.client.post(url, **headers)
 
@@ -107,3 +109,15 @@ class MarkNotificationsAsReadTestCase(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertTrue(notifs[0].read)
         self.assertTrue(notifs[1].read)
+
+    def test_failure_notific_as_read(self):
+        """fail to mark all notifications as read"""
+        self.client.force_login(self.user)
+        url = reverse(
+            "notifications:mark_top_read",
+        )
+        print("I am here")
+        with self.assertRaises(HtmxFailureError) as e:
+            resp = self.client.post(url)  # noqa
+
+        self.assertEqual(str(e.exception), _("Something went wrong.Please try later"))

--- a/src/notifications/tests/test_views.py
+++ b/src/notifications/tests/test_views.py
@@ -50,27 +50,26 @@ class NotificationsFabricTestCase(TestCase):
         self.assertEqual(notif_to_author.recipient, self.author_comment)
         self.assertEqual(notif_count, 1)
 
+    def test_no_notif_own_reply_to_yourself(self):
+        """if user reply's own comment -> no notifications"""
+        self.client.force_login(self.author_comment)
+        url = reverse(
+            "comments:process_comm",
+            kwargs={"post_uuid": self.post.uuid},
+        )
+        data = {
+            "body": "Sally reply's to herself",
+            "comm_parent_id": self.comment.id,
+            "post": self.post,
+        }
+        headers = {"HTTP_HX-Request": "true"}
 
-def test_no_notif_own_reply_to_yourself(self):
-    """if user reply's own comment -> no notifications"""
-    self.client.force_login(self.author_comment)
-    url = reverse(
-        "comments:process_comm",
-        kwargs={"post_uuid": self.post.uuid},
-    )
-    data = {
-        "body": "Sally reply's to herself",
-        "comm_parent_id": self.comment.id,
-        "post": self.post,
-    }
-    headers = {"HTTP_HX-Request": "true"}
+        resp = self.client.post(url, data=data, **headers)
 
-    resp = self.client.post(url, data=data, **headers)
+        notif_count = Notification.objects.count()
 
-    notif_count = Notification.objects.count()
-
-    self.assertEqual(resp.status_code, 204)
-    self.assertEqual(notif_count, 0)
+        self.assertEqual(resp.status_code, 204)
+        self.assertEqual(notif_count, 0)
 
 
 @override_settings(LANGUAGE_CODE="en", LANGUAGES=(("en", "English"),))

--- a/src/notifications/tests/test_web.py
+++ b/src/notifications/tests/test_web.py
@@ -1,0 +1,47 @@
+from django.contrib.auth import get_user_model
+from django.test import override_settings
+from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
+from django_webtest import WebTest
+
+from src.accounts.tests.factories import UserFactory
+from src.comments.models import Comment
+from src.notifications.models import Notification
+from src.posts.tests.factories import PostFactory
+
+User = get_user_model()
+
+
+@override_settings(LANGUAGE_CODE="en", LANGUAGES=(("en", "English"),))
+class NotificationsActionsTestCase(WebTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.user = UserFactory(username="tata")
+        self.author_comment = UserFactory(username="sally")
+        self.post = PostFactory.create(
+            title_en="Bell's palsy",
+            content_en="herpes virus, treatment,prednisone",
+            status=2,
+        )
+        self.root_comment = Comment.add_root(
+            post=self.post, user=self.author_comment, body="it's me, root comment"
+        )
+        self.notif_1 = Notification.objects.create(
+            recipient=self.user, parent_comment=self.root_comment, post=self.post
+        )
+        self.notif_2 = Notification.objects.create(
+            recipient=self.user, parent_comment=self.root_comment, post=self.post
+        )
+
+    def test_notific_on_reply_comment(self):
+        """div notifications in dropdown exists"""
+
+        self.app.set_user(self.user)
+        url = reverse("home")
+
+        resp = self.app.get(url)
+
+        dropdow_notifications = resp.html.find("div", id="notis")
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertIsNotNone(dropdow_notifications)

--- a/src/notifications/views.py
+++ b/src/notifications/views.py
@@ -1,24 +1,32 @@
 from django.contrib.auth.decorators import login_required
-from django.http import HttpResponse, HttpResponseRedirect
+from django.http import HttpResponse
 from django.shortcuts import render
-from django.views.generic import View
+from django.utils.translation import gettext_lazy as _
 
+from src.contacts.exceptions import HtmxFailureError
 from src.notifications.models import Notification
 
 
 @login_required
 def get_top_five(request):
+    """last five notification: only about replied comments"""
     context = {"top_five": Notification.objects.get_first_five(request.user)}
     return render(request, "notifications/partial.html", context)
 
 
 @login_required
 def make_notifs_read(request):
-    """htmx post"""
-    Notification.objects.make_all_read(request.user)
-    return HttpResponse(
-        headers={
-            "HX-Redirect": "/",
-        },
-    )
-    # return HttpResponseRedirect(request.headers["referer"])
+    """htmx based post request;
+    click button in menu drop-down makes all notifications;
+    same page displayed
+    """
+    if request.htmx and request.method == "POST":
+        Notification.objects.make_all_read(request.user)
+        path_to_go = request.headers["Referer"]
+        return HttpResponse(
+            headers={
+                "HX-Redirect": path_to_go,
+            },
+        )
+    else:
+        raise HtmxFailureError(_("Something went wrong.Please try later"))

--- a/src/notifications/views.py
+++ b/src/notifications/views.py
@@ -1,5 +1,5 @@
 from django.contrib.auth.decorators import login_required
-from django.http import HttpResponseRedirect
+from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import render
 from django.views.generic import View
 
@@ -16,4 +16,9 @@ def get_top_five(request):
 def make_notifs_read(request):
     """htmx post"""
     Notification.objects.make_all_read(request.user)
-    return HttpResponseRedirect(request.headers["referer"])
+    return HttpResponse(
+        headers={
+            "HX-Redirect": "/",
+        },
+    )
+    # return HttpResponseRedirect(request.headers["referer"])

--- a/src/posts/tests/test_view.py
+++ b/src/posts/tests/test_view.py
@@ -8,198 +8,199 @@ from src.posts.models.post_model import Post
 
 from .factories import PostFactory
 
-# class PostListTestCase(TestCase):
-#     def setUp(self) -> None:
-#         self.user = UserFactory()
-#         self.staff = StaffUserFactory()
-#         self.posts_public = PostFactory.create_batch(
-#             10, status=Post.CurrentStatus.PUB.value
-#         )
-#         self.posts_drafts = PostFactory.create_batch(
-#             2, status=Post.CurrentStatus.DRAFT.value
-#         )
-#         self.client = Client()
 
-#     @override_settings(LANGUAGE_CODE="ru", LANGUAGES=(("ru", "Russian"),))
-#     def test_view_public_posts_ru(self):
-#         """show only public posts; lang ru in url path"""
-#         path = reverse("posts:post_list")
-#         lang = path.split("/")[1]
-#         response = self.client.get(path)
+class PostListTestCase(TestCase):
+    def setUp(self) -> None:
+        self.user = UserFactory()
+        self.staff = StaffUserFactory()
+        self.posts_public = PostFactory.create_batch(
+            10, status=Post.CurrentStatus.PUB.value
+        )
+        self.posts_drafts = PostFactory.create_batch(
+            2, status=Post.CurrentStatus.DRAFT.value
+        )
+        self.client = Client()
 
-#         posts_count = Post.objects.get_public().count()
+    @override_settings(LANGUAGE_CODE="ru", LANGUAGES=(("ru", "Russian"),))
+    def test_view_public_posts_ru(self):
+        """show only public posts; lang ru in url path"""
+        path = reverse("posts:post_list")
+        lang = path.split("/")[1]
+        response = self.client.get(path)
 
-#         self.assertEqual(response.status_code, 200)
-#         self.assertEqual(posts_count, 10)
-#         self.assertEqual("ru", lang)
-#         self.assertEqual(
-#             response.context_data["paginator"].count, Post.objects.get_public().count()
-#         )
+        posts_count = Post.objects.get_public().count()
 
-#     @override_settings(LANGUAGE_CODE="en", LANGUAGES=(("en", "English"),))
-#     def test_public_posts_en(self):
-#         """show only public posts; lang en in url path"""
-#         path = reverse("posts:post_list")
-#         lang = path.split("/")[1]
-#         response = self.client.get(path)
-#         posts_count = Post.objects.get_public().count()
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(posts_count, 10)
+        self.assertEqual("ru", lang)
+        self.assertEqual(
+            response.context_data["paginator"].count, Post.objects.get_public().count()
+        )
 
-#         self.assertEqual(response.status_code, 200)
-#         self.assertEqual("en", lang)
-#         self.assertEqual(posts_count, 10)
-#         self.assertEqual(
-#             response.context_data["paginator"].count, Post.objects.get_public().count()
-#         )
+    @override_settings(LANGUAGE_CODE="en", LANGUAGES=(("en", "English"),))
+    def test_public_posts_en(self):
+        """show only public posts; lang en in url path"""
+        path = reverse("posts:post_list")
+        lang = path.split("/")[1]
+        response = self.client.get(path)
+        posts_count = Post.objects.get_public().count()
 
-
-# class PostCategsTestCase(TestCase):
-#     def setUp(self) -> None:
-#         self.categ_root_1 = Category.add_root(name="parent1")
-#         self.categ_root_2 = self.categ_root_1.add_sibling(name="parent2")
-#         self.categ_kid1 = self.categ_root_2.add_child(name="kid1_parent2")
-#         self.categ_kid2 = self.categ_root_2.add_child(name="kid2_parent2")
-#         self.post_1 = PostFactory(
-#             status=Post.CurrentStatus.PUB.value, categ=self.categ_root_1
-#         )
-#         self.post_2 = PostFactory(
-#             status=Post.CurrentStatus.PUB.value, categ=self.categ_kid1
-#         )
-#         self.post_3 = PostFactory(
-#             status=Post.CurrentStatus.PUB.value, categ=self.categ_kid2
-#         )
-#         self.post_4 = PostFactory(categ=self.categ_kid2)
-#         self.post_5 = PostFactory()
-#         self.client = Client()
-
-#     @override_settings(LANGUAGE_CODE="en", LANGUAGES=(("en", "English"),))
-#     def test_posts_categ_with_kids(self):
-#         """display public posts related to a given categ with decendants)"""
-#         path = reverse("posts:cat_search", kwargs={"slug": self.categ_root_2.slug})
-
-#         response = self.client.get(path)
-#         posts = response.context["posts"]
-
-#         self.assertEqual(response.status_code, 200)
-#         self.assertEqual(len(posts), 2)
-
-#     @override_settings(LANGUAGE_CODE="en", LANGUAGES=(("en", "English"),))
-#     def test_posts_categ_no_kids(self):
-#         """display public posts related to a given categ
-#         without decendants)"""
-#         categs_count = Category.objects.count()
-#         path = reverse("posts:cat_search", kwargs={"slug": self.categ_root_1.slug})
-
-#         response = self.client.get(path)
-#         posts = response.context["posts"]
-
-#         self.assertEqual(response.status_code, 200)
-#         self.assertEqual(len(posts), 1)
-#         self.assertEqual(categs_count, 5)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual("en", lang)
+        self.assertEqual(posts_count, 10)
+        self.assertEqual(
+            response.context_data["paginator"].count, Post.objects.get_public().count()
+        )
 
 
-# class PostSearchLangTestCase(TestCase):
-#     def setUp(self) -> None:
-#         super().setUp()
+class PostCategsTestCase(TestCase):
+    def setUp(self) -> None:
+        self.categ_root_1 = Category.add_root(name="parent1")
+        self.categ_root_2 = self.categ_root_1.add_sibling(name="parent2")
+        self.categ_kid1 = self.categ_root_2.add_child(name="kid1_parent2")
+        self.categ_kid2 = self.categ_root_2.add_child(name="kid2_parent2")
+        self.post_1 = PostFactory(
+            status=Post.CurrentStatus.PUB.value, categ=self.categ_root_1
+        )
+        self.post_2 = PostFactory(
+            status=Post.CurrentStatus.PUB.value, categ=self.categ_kid1
+        )
+        self.post_3 = PostFactory(
+            status=Post.CurrentStatus.PUB.value, categ=self.categ_kid2
+        )
+        self.post_4 = PostFactory(categ=self.categ_kid2)
+        self.post_5 = PostFactory()
+        self.client = Client()
 
-#         self.post_1 = PostFactory.create(
-#             title_ru="Паралич Бэлла",
-#             content_ru="вирус герпеса, лечение преднизолоном,инфекциями",
-#             title_en="Bell's palsy",
-#             content_en="herpes virus, treatment,prednisone,infections",
-#             status=2,
-#         )
+    @override_settings(LANGUAGE_CODE="en", LANGUAGES=(("en", "English"),))
+    def test_posts_categ_with_kids(self):
+        """display public posts related to a given categ with decendants)"""
+        path = reverse("posts:cat_search", kwargs={"slug": self.categ_root_2.slug})
 
-#         self.post_2 = PostFactory(
-#             title_ru="Инфекция кожи",
-#             title_en="Skin infections",
-#             content_ru="Лечение чего-то там",
-#             content_en="Treatment",
-#             status=2,
-#         )
-#         self.post_3 = PostFactory(
-#             status=2,
-#             title_ru="Гипербиллирубинемия у новорождённых",
-#             content_ru="Фото терапия ",
-#             title_en="Newborns Hyperbilirubinemia",
-#             content_en="Photo therapy",
-#         )
-#         self.post_4 = PostFactory(
-#             status=0,
-#             title_ru="Гипербиллирубинемия у новорождённых",
-#             content_ru="Фото терапия ",
-#             title_en="Newborns Hyperbilirubinemia",
-#             content_en="Photo therapy",
-#         )
-#         self.post_5 = PostFactory(
-#             status=1,
-#             title_ru="Гипербиллирубинемия у новорождённых",
-#             content_ru="Фото терапия ",
-#             title_en="Newborns Hyperbilirubinemia",
-#             content_en="Photo therapy",
-#         )
+        response = self.client.get(path)
+        posts = response.context["posts"]
 
-#     @override_settings(LANGUAGE_CODE="ru", LANGUAGES=(("ru", "Russian"),))
-#     def test_ru(self):
-#         """search in russian lang content"""
-#         url = reverse("posts:search_posts")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(posts), 2)
 
-#         search_word = "инфекция"
-#         data = {"q": search_word, "lang": "ru", "honeypot": ""}
-#         resp = self.client.get(url, data)
+    @override_settings(LANGUAGE_CODE="en", LANGUAGES=(("en", "English"),))
+    def test_posts_categ_no_kids(self):
+        """display public posts related to a given categ
+        without decendants)"""
+        categs_count = Category.objects.count()
+        path = reverse("posts:cat_search", kwargs={"slug": self.categ_root_1.slug})
 
-#         posts = resp.context_data["posts"]
-#         self.assertEqual(resp.status_code, 200)
-#         self.assertEqual(len(posts), 2)
+        response = self.client.get(path)
+        posts = response.context["posts"]
 
-#     @override_settings(LANGUAGE_CODE="ru", LANGUAGES=(("ru", "Russian"),))
-#     def test_not_public_ru(self):
-#         """results for posts only with status public"""
-#         url = reverse("posts:search_posts")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(posts), 1)
+        self.assertEqual(categs_count, 5)
 
-#         search_word = "Гипербиллирубинемия"
-#         data = {"q": search_word, "lang": "ru", "honeypot": ""}
-#         resp = self.client.get(url, data)
 
-#         posts = resp.context_data["posts"]
-#         self.assertEqual(resp.status_code, 200)
-#         self.assertEqual(len(posts), 1)
+class PostSearchLangTestCase(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
 
-#     @override_settings(LANGUAGE_CODE="ru", LANGUAGES=(("ru", "Russian"),))
-#     def test_no_results_ru(self):
-#         """no search results in russian"""
-#         url = reverse("posts:search_posts")
-#         search_word = "квартирус"
-#         data = {"q": search_word, "lang": "ru", "honeypot": ""}
-#         resp = self.client.get(url, data)
+        self.post_1 = PostFactory.create(
+            title_ru="Паралич Бэлла",
+            content_ru="вирус герпеса, лечение преднизолоном,инфекциями",
+            title_en="Bell's palsy",
+            content_en="herpes virus, treatment,prednisone,infections",
+            status=2,
+        )
 
-#         posts = resp.context_data["posts"]
+        self.post_2 = PostFactory(
+            title_ru="Инфекция кожи",
+            title_en="Skin infections",
+            content_ru="Лечение чего-то там",
+            content_en="Treatment",
+            status=2,
+        )
+        self.post_3 = PostFactory(
+            status=2,
+            title_ru="Гипербиллирубинемия у новорождённых",
+            content_ru="Фото терапия ",
+            title_en="Newborns Hyperbilirubinemia",
+            content_en="Photo therapy",
+        )
+        self.post_4 = PostFactory(
+            status=0,
+            title_ru="Гипербиллирубинемия у новорождённых",
+            content_ru="Фото терапия ",
+            title_en="Newborns Hyperbilirubinemia",
+            content_en="Photo therapy",
+        )
+        self.post_5 = PostFactory(
+            status=1,
+            title_ru="Гипербиллирубинемия у новорождённых",
+            content_ru="Фото терапия ",
+            title_en="Newborns Hyperbilirubinemia",
+            content_en="Photo therapy",
+        )
 
-#         self.assertEqual(resp.status_code, 200)
-#         self.assertEqual(len(posts), 0)
+    @override_settings(LANGUAGE_CODE="ru", LANGUAGES=(("ru", "Russian"),))
+    def test_ru(self):
+        """search in russian lang content"""
+        url = reverse("posts:search_posts")
 
-#     @override_settings(LANGUAGE_CODE="en", LANGUAGES=(("en", "English"),))
-#     def test_in_en(self):
-#         """search in english lang content"""
-#         url = reverse("posts:search_posts")
-#         search_word = "Hyperbilirubinemia"
-#         data = {"q": search_word, "lang": "en", "honeypot": ""}
-#         resp = self.client.get(url, data)
+        search_word = "инфекция"
+        data = {"q": search_word, "lang": "ru", "honeypot": ""}
+        resp = self.client.get(url, data)
 
-#         posts = resp.context_data["posts"]
-#         self.assertEqual(resp.status_code, 200)
-#         self.assertEqual(len(posts), 1)
+        posts = resp.context_data["posts"]
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(posts), 2)
 
-#     @override_settings(LANGUAGE_CODE="en", LANGUAGES=(("en", "English"),))
-#     def test_no_results_en(self):
-#         """no results in english"""
-#         url = reverse("posts:search_posts")
-#         search_word = "kite"
-#         data = {"q": search_word, "lang": "en", "honeypot": ""}
-#         resp = self.client.get(url, data)
+    @override_settings(LANGUAGE_CODE="ru", LANGUAGES=(("ru", "Russian"),))
+    def test_not_public_ru(self):
+        """results for posts only with status public"""
+        url = reverse("posts:search_posts")
 
-#         posts = resp.context_data["posts"]
-#         self.assertEqual(resp.status_code, 200)
-#         self.assertEqual(len(posts), 0)
+        search_word = "Гипербиллирубинемия"
+        data = {"q": search_word, "lang": "ru", "honeypot": ""}
+        resp = self.client.get(url, data)
+
+        posts = resp.context_data["posts"]
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(posts), 1)
+
+    @override_settings(LANGUAGE_CODE="ru", LANGUAGES=(("ru", "Russian"),))
+    def test_no_results_ru(self):
+        """no search results in russian"""
+        url = reverse("posts:search_posts")
+        search_word = "квартирус"
+        data = {"q": search_word, "lang": "ru", "honeypot": ""}
+        resp = self.client.get(url, data)
+
+        posts = resp.context_data["posts"]
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(posts), 0)
+
+    @override_settings(LANGUAGE_CODE="en", LANGUAGES=(("en", "English"),))
+    def test_in_en(self):
+        """search in english lang content"""
+        url = reverse("posts:search_posts")
+        search_word = "Hyperbilirubinemia"
+        data = {"q": search_word, "lang": "en", "honeypot": ""}
+        resp = self.client.get(url, data)
+
+        posts = resp.context_data["posts"]
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(posts), 1)
+
+    @override_settings(LANGUAGE_CODE="en", LANGUAGES=(("en", "English"),))
+    def test_no_results_en(self):
+        """no results in english"""
+        url = reverse("posts:search_posts")
+        search_word = "kite"
+        data = {"q": search_word, "lang": "en", "honeypot": ""}
+        resp = self.client.get(url, data)
+
+        posts = resp.context_data["posts"]
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(posts), 0)
 
 
 class PostDetailCommentsTestCase(TestCase):

--- a/src/posts/urls.py
+++ b/src/posts/urls.py
@@ -14,4 +14,7 @@ urlpatterns = [
         PostTagSearch.as_view(),
         name="tag_search",
     ),
+    path(
+        "comments/<slug:slug>/<thread_uuid>/", PostComment.as_view(), name="get_branch"
+    ),
 ]

--- a/src/profiles/views.py
+++ b/src/profiles/views.py
@@ -5,7 +5,6 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import View
 
-from .exceptions import NoAjaxError
 from .forms import ProfileForm
 from .models import Profile
 
@@ -19,7 +18,7 @@ class ProfileView(LRM, View):
         return render(request, "profiles/profile_detail.html", ctx)
 
     def post(self, request, **kwargs):
-        # ajax request
+        # ajax(fetch) request
         # request.headers.get("x-requested-with") == "XMLHttpRequest")
         uuid = kwargs.get("uuid")
         profile = get_object_or_404(Profile, uuid=uuid)

--- a/src/templates/notifications/partial.html
+++ b/src/templates/notifications/partial.html
@@ -9,7 +9,11 @@
    <hr>
    {% for n in top_five %}
    <div>{{n.text|truncatewords:50|linebreaks}}</div>
-   <div>Details: <a href="#">{% trans 'See details' %}</a></div>
+   <div>Details:
+      <a href="{% url 'posts:get_branch'  slug=n.post.slug thread_uuid=n.parent_comment.uuid%}"
+      >{% trans 'See details' %}
+     </a>
+   </div>
    <hr>
    {% endfor %}
 </div>

--- a/src/templates/posts/post_detail.html
+++ b/src/templates/posts/post_detail.html
@@ -3,11 +3,8 @@
 {% block content %}
   <div class="row">
   <aside class="col-md-3 col-sm-12">
-    <!-- <nav role="navigation" aria-label="Sidebar Navigation">
-      <div class="list-group"> -->
-        {% show_categs %}
-        <!-- </div>
-    </nav>     -->
+    {% show_categs %}
+
   </aside>
   <div class="col-md-6 col-sm-12">
 
@@ -56,19 +53,36 @@
       </div>
     </div>
     {% if comments %}
-    <div class="">Comments : {{comms_total}}</div>
+    <div class="number"><string>{% trans 'Total comments' %} : {{comms_total}}</string></div>
+
     <div class="row comms">
       <div class="col-sm-3"></div>
         <div class="col-sm-6 col-md-12 ">
+          {% if thread_uuid %}
+          <div class="mb-2"><button class="btn btn-secondary"
+          hx-get="{% url 'comments:all_comms' post.uuid %}"
+          hx-target="#mycomms"
+            >{% trans 'Refresh all comments' %}</button>
+          </div>
           <div id="comms_list"
             hx-trigger="load, updateCommList from:body"
-            hx-get="{% url 'comments:all_comms' post_uuid=post.uuid %}"
+            hx-get="{% url 'comments:select_comms' post_uuid=post.uuid thread_uuid=thread_uuid %}"
             hx-target="#mycomms">
             <div id="mycomms"class="comms_bg"></div>
           </div>
+          {% else %}
+          <div id="comms_list"
+          hx-trigger="load, updateCommList from:body"
+          hx-get="{% url 'comments:all_comms' post.uuid %}"
+          hx-target="#mycomms">
+          <div id="mycomms"class="comms_bg"></div>
+        </div>
+
+          {% endif %}
         </div>
       <div class="col-sm-3"></div>
     </div>
+
   </div>
   {% endif %}
 {% endblock%}


### PR DESCRIPTION
Basic func for Comments and Notifications implemented on this branch.
**Nested comments based on django-treebread package (Materialized Path trees), django templates and htmx for crud on comments.**
Inspired [this](https://blog.benoitblanchon.fr/django-htmx-modal-form/)
Flow
List of comments available on post detail page for all users.
Loading this page activates htmx 'load' trigger. As a result get request fetches list of comments.They are rendered in a div class "comms" on the same post detail page. (The same flow happens when list of comments gets updated: trigger == "updateCommList")
Post detailed page renders a CommentForm only for authenticated users.
List of comments gets rendered recursively via custom template tag recursetree that expects comments collection. (Something like mptt)
Authenticated comment authors can edit and delete their comments via bootstrap5 modal.
Deleted comment is rendered as an empty card (UI) but still present in db for the sake of tree nodes consistency.

- [ ] Feedback: handle custom exception (HtmxFailure) and it's testing
- [ ] optimize (get rid of) ugly {{node.user.profile.avatar.url}}
- [ ] Looking for more elegant way to remove logic from the template
- [ ]  suitable caching where it's possible

